### PR TITLE
Fix link to latest released version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It was developed and is being maintained by [euroCRIS](http://www.eurocris.org/)
 
 This project contains the Entity-Relationship model of CERIF.
 You can browse the **documentation of the 
-[latest released version (1.6.1)](https://cdn.rawgit.com/EuroCRIS/CERIF-DataModel/8743066b/documentation/MInfo.html)**
+[latest released version (1.6.1)](https://rawgit.com/EuroCRIS/CERIF-DataModel/8743066b/documentation/MInfo.html)**
 or the [development version](https://rawgit.com/EuroCRIS/CERIF-DataModel/develop/documentation/MInfo.html). 
 
 The model is currently maintained using the [TOAD Data Modeler](https://www.quest.com/products/toad-data-modeler/ "The vendor webpage") tool.


### PR DESCRIPTION
The URL to the latest version seems to be incorrect. I replaced it using as reference the URL to the development version in this same document. 